### PR TITLE
Remove DXcluster commands from default config

### DIFF
--- a/defaultConfig.js
+++ b/defaultConfig.js
@@ -19,9 +19,6 @@ const defaultConfig = {
     callsign: 'YOUR-CALLSIGN-HERE',              // User callsign for login
     loginPrompt: 'login:',     // Expected login prompt from the DXCluster server
     commandsAfterLogin: [      // Commands to execute after successful login
-      'SET/NAME JOHN',         // e.g., 'SET/NAME John'
-      'SET/SKIMMER CW',
-      'SET/SEEME',
     ],
     reconnect: {
       initialDelay: 10000,      // Initial delay before reconnection attempt in milliseconds


### PR DESCRIPTION
If the example commands stored in `commandsAfterLogin` loaded from the defaultConfig.js are removed in the running application (e.g. no need for extra commands) and saved, they get overwritten by the default settings at the next start of the application.

This is just a temporary solution, the root cause is `function loadConfig()` comparing the the value array expecting the same number of keys as in defaultConfig.js