### PR TITLE
Support for MultiFlex Connections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ out/
 *.map
 /electron-builder.json
 /releases/
+.vscode

--- a/defaultConfig.js
+++ b/defaultConfig.js
@@ -97,6 +97,7 @@ const defaultConfig = {
     apiKey: 'YOUR-WAVELOG-API-KEY-HERE',
     station_location_ids: [], // Wavelog station location (QTH) IDs from where to search for DXCC confirmation data
     radioName: 'wavelog-flex-integrator',
+    multiFlexEnabled: false,
   },
 
   // ==============================

--- a/defaultConfig.js
+++ b/defaultConfig.js
@@ -96,6 +96,7 @@ const defaultConfig = {
     URL: 'https://wavelog.example.com/index.php',
     apiKey: 'YOUR-WAVELOG-API-KEY-HERE',
     station_location_ids: [], // Wavelog station location (QTH) IDs from where to search for DXCC confirmation data
+    radioName: 'wavelog-flex-integrator',
   },
 
   // ==============================

--- a/flexradio_message_parser.js
+++ b/flexradio_message_parser.js
@@ -95,6 +95,9 @@ class FlexRadioMessageParser extends EventEmitter {
       case 'slice':
         this.parseSliceStatus(handle, statusContent);
         break;
+      case 'client':
+        this.parseClientStatus(handle, statusContent);
+        break;
       // Add more cases as needed for different status types
       default:
         // Emit a generic status event for unhandled types
@@ -155,6 +158,25 @@ class FlexRadioMessageParser extends EventEmitter {
       this.emit('sliceStatus', { handle, index, statusMessage });
     } else {
       this.emit('error', new Error(`parseSliceStatus: Failed to parse slice status message: ${statusContent}`));
+    }
+  }
+
+  /**
+     * Parses client status messages and emits events accordingly.
+     * @param {string} handle - The handle associated with the message.
+     * @param {string} statusContent - The content of the status message.
+     */
+  parseClientStatus(handle, statusContent) {
+    // We need to correctly extract the index and the rest of the status message
+    const match = statusContent.match(/^client\s+0x([0-9A-F]+)\s+(.*)/);
+    // group 1 - gui client handle
+    // group 2 - status message
+    if (match) {
+      const guiHandle = match[1];
+      const statusMessage = match[2];
+      this.emit('clientStatus', { handle:guiHandle, statusMessage});
+    } else {
+      this.emit('error', new Error(`parseClientStatus: Failed to parse client status message: ${statusContent}`));
     }
   }
 

--- a/flexradio_message_parser.js
+++ b/flexradio_message_parser.js
@@ -172,7 +172,7 @@ class FlexRadioMessageParser extends EventEmitter {
     // group 1 - gui client handle
     // group 2 - status message
     if (match) {
-      const guiHandle = match[1];
+      const guiHandle = match[1].replace(/^0+/, ''); // Remove leading zeros
       const statusMessage = match[2];
       this.emit('clientStatus', { handle:guiHandle, statusMessage});
     } else {

--- a/index.html
+++ b/index.html
@@ -355,6 +355,10 @@
             <div class="mb-3">
               <label for="wavelogRadioName" class="form-label">Radio name in Wavelog</label>
               <input type="text" class="form-control" id="wavelogRadioName" placeholder="wave-flex-integrator" />
+
+              <!-- Checkbox for enabling multiflex support -->
+              <label for="multiFlexEnabled">Enable MultiFlex Support:</label>
+              <input type="checkbox" id="multiFlexEnabled" name="multiFlexEnabled">
             </div>
   
             <!-- LoTW Configuration -->

--- a/index.html
+++ b/index.html
@@ -352,6 +352,10 @@
               <label for="stationLocationIds" class="form-label">Station Location IDs (comma separated)</label>
               <input type="text" class="form-control" id="stationLocationIds" placeholder="e.g., 1,3" />
             </div>
+            <div class="mb-3">
+              <label for="wavelogRadioName" class="form-label">Radio name in Wavelog</label>
+              <input type="text" class="form-control" id="wavelogRadioName" placeholder="wave-flex-integrator" />
+            </div>
   
             <!-- LoTW Configuration -->
             <h4 class="mt-4">Logbook of The World (LoTW)</h4>

--- a/main.js
+++ b/main.js
@@ -410,8 +410,10 @@ function isConfigValid() {
     !config.wavelogAPI ||
     !config.wavelogAPI.URL ||
     !config.wavelogAPI.apiKey ||
+    !config.wavelogAPI.radioName ||
     config.wavelogAPI.URL.trim() === '' ||
-    config.wavelogAPI.apiKey.trim() === ''
+    config.wavelogAPI.apiKey.trim() === '' ||
+    config.wavelogAPI.radioName.trim() === ''
   ) {
     return false;
   }

--- a/renderer.js
+++ b/renderer.js
@@ -271,6 +271,11 @@ function populateForm(config) {
     wavelogRadioNameInput.value = config.wavelogAPI.radioName;
   }
 
+  const multiFlexEnabledCheckbox = document.getElementById('multiFlexEnabled');
+  if (multiFlexEnabledCheckbox) {
+    multiFlexEnabledCheckbox.checked = config.wavelogAPI.multiFlexEnabled;
+  }  
+
   // Populate LoTW Configuration
   const maxDaysConsideredTrueInput = document.getElementById('maxDaysConsideredTrue');
   if (maxDaysConsideredTrueInput) {
@@ -486,6 +491,7 @@ if (configForm) {
           .map((id) => parseInt(id.trim(), 10))
           .filter((id) => !isNaN(id)),
         radioName: document.getElementById('wavelogRadioName').value.trim(),
+        multiFlexEnabled: document.getElementById('multiFlexEnabled').checked,
       },
       loTW: {
         max_days_lotw_considered_true: parseInt(

--- a/renderer.js
+++ b/renderer.js
@@ -265,6 +265,11 @@ function populateForm(config) {
   if (stationLocationIdsInput) {
     stationLocationIdsInput.value = config.wavelogAPI.station_location_ids.join(', ');
   }
+  
+  const wavelogRadioNameInput = document.getElementById('wavelogRadioName');
+  if (wavelogRadioNameInput) {
+    wavelogRadioNameInput.value = config.wavelogAPI.radioName;
+  }
 
   // Populate LoTW Configuration
   const maxDaysConsideredTrueInput = document.getElementById('maxDaysConsideredTrue');
@@ -480,6 +485,7 @@ if (configForm) {
           .value.split(',')
           .map((id) => parseInt(id.trim(), 10))
           .filter((id) => !isNaN(id)),
+        radioName: document.getElementById('wavelogRadioName').value.trim(),
       },
       loTW: {
         max_days_lotw_considered_true: parseInt(

--- a/slice.js
+++ b/slice.js
@@ -19,14 +19,25 @@ class Slice {
     this.index_letter = '';
     this.xit_on = false;
     this.xit_freq = 0;
+    this.handle = ''; // GUI Client Handle of the slice
+    this.stationName = ''; // Station name of the slice
     // Add other properties as needed
   }
 
+
+  /**
+   * Updates the station name of the slice based on the provided handleStationMap.
+   * @param {Map<string, string>} handleStationMap - A map of GUI Client Handles to station names.
+   */
+  updateStationName(handleStationMap) { 
+    this.stationName = handleStationMap.get(this.handle) || '';
+  }
   /**
    * Updates the slice's status based on the provided status message.
+   * @param {string} handle - The GUI Client Handle for the slice
    * @param {string} statusMessage - The status message content.
    */
-  statusUpdate(statusMessage) {
+  statusUpdate(handle, statusMessage) {
     // Split the status message into key-value pairs
     const keyValuePairs = statusMessage.match(/(?:[^\s"]+|"[^"]*")+/g);
 
@@ -40,7 +51,7 @@ class Slice {
     if (keyValuePairs[0] === 'slice') {
       startIndex = 2; // Skip 'slice' and the index
     }
-
+    this.handle = handle; 
     for (let i = startIndex; i < keyValuePairs.length; i++) {
       const pair = keyValuePairs[i];
       const equalIndex = pair.indexOf('=');

--- a/wavelog_client.js
+++ b/wavelog_client.js
@@ -50,7 +50,9 @@ class WavelogClient extends EventEmitter {
 
       const payload = {
         key: this.config.wavelogAPI.apiKey,
-        radio: `${this.config.wavelogAPI.radioName} (Slice ${activeTXSlice.index + 1})`,
+        radio: this.config.wavelogAPI.multiFlexEnabled && activeTXSlice.stationName !== ''
+          ? `${this.config.wavelogAPI.radioName} (${activeTXSlice.stationName})`
+          : `${this.config.wavelogAPI.radioName}`,
         frequency: adjustedFrequencyHz,
         mode: activeTXSlice.mode,
       };

--- a/wavelog_client.js
+++ b/wavelog_client.js
@@ -50,7 +50,7 @@ class WavelogClient extends EventEmitter {
 
       const payload = {
         key: this.config.wavelogAPI.apiKey,
-        radio: 'wave-flex-integrator',
+        radio: `${this.config.wavelogAPI.radioName} (Slice ${activeTXSlice.index + 1})`,
         frequency: adjustedFrequencyHz,
         mode: activeTXSlice.mode,
       };


### PR DESCRIPTION
Hi everyone!

over the holidays I've had the chance to take on Issue #28 where the integrator tool cannot handle multiple connections via MultiFlex. I have also added the capability to let the user define the Radio name to be displayed in Wavelog. 

## What has changed

The default behavior has not changed. One must manually activate the new "Enable MultiFlex Support" checkbox in the configuration tab. Once enabled and restarted, you will see the radios differently in Wavelog. They will be called "RADIO-NAME (STATION-NAME)". The radio name can be user-defined in the configuration tab and the Station names are the station names as seen in the bottom middle of SmartSDR or the drop-down menus of the DAX/CAT Tools. This way, you can precisely select which TX slice your Wavelog will follow. 

This PR Fixes #28.

### Known Issues

The handling of spots is questionable. All connected users will see the spots this tool feeds into the waterfall. Anyone clicking any spot will trigger the Wavelog live QSO popup on the device this tool is running on. I am not quite sure how we should handle the spots in a MultiFlex scenario. Open for any discussion!

## Type of change

- [x] Bug fix (non-breaking change): See Issue #28 
- [x] New feature (non-breaking change): Added the capability for the user to define the Wavelog radio name.


## How Has This Been Tested?

I own a Flex-8400. I tested it by connecting two Windows devices at the same time via SmartLink.

## Checklist:

- [x] I have read the contributing document
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
